### PR TITLE
Fix <init>

### DIFF
--- a/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt
+++ b/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt
@@ -41,9 +41,11 @@ import javax.crypto.spec.IvParameterSpec
  */
 class CryptoManager {
 
-    private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
+    if (!isLoaded) {
         load(null)
     }
+}
 
     private val encryptCipher
         get() = Cipher.getInstance(TRANSFORMATION).apply {

--- a/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt
+++ b/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt
@@ -41,10 +41,9 @@ import javax.crypto.spec.IvParameterSpec
  */
 class CryptoManager {
 
-private val keyStore = KeyStore.getInstance("AndroidKeyStore").apply {
-    if (!isLoaded) {
-        load(null)
-    }
+private val keyStore = KeyStore.getInstance("AndroidKeyStore")
+if (!keyStore.isLoaded) {
+    keyStore.load(null)
 }
 
     private val encryptCipher


### PR DESCRIPTION
# Fix: `<init>`

## Explanation

This error occurs because the `KeyStore` instance is not properly initialized. The `load()` method is called on a null object reference, which causes the error.

---

## Modified Method

| Property | Value |
|---|---|
| Method | `<init>` |
| Class | `com.phpbg.easysync.settings.CryptoManager` |
| File | `/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.phpbg.easysync_25.apk/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt` |
| Status | `SUCCESS` |

---

## Changed File

```text
/mnt/c/Users/Antonow/Documents/tcc_v3/outputs/cloned_projects/com.phpbg.easysync_25.apk/app/src/main/java/com/phpbg/easysync/settings/CryptoManager.kt
```

---


## Validation Checklist

- [x] Method replaced in source file
- [x] Repository updated
- [x] Commit generated
- [ ] Manual review required
- [ ] CI validation pending

---

Repair Pipeline